### PR TITLE
TypeScriptを5.9.3に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,13 @@
         "@vitest/coverage-v8": "^3.2.4",
         "happy-dom": "^18.0.1",
         "lil-gui": "^0.20.0",
-        "typescript": "~5.8.3",
+        "typescript": "~5.9.3",
         "vite": "^7.1.2",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2341,9 +2344,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "happy-dom": "^18.0.1",
     "lil-gui": "^0.20.0",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.3",
     "vite": "^7.1.2",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"


### PR DESCRIPTION
## 概要

- `typescript`を`~5.8.3`から`~5.9.3`(5.x系最新)に更新
- `tsconfig.json`の`baseUrl`/`moduleResolution: "node"`はTypeScript 6.0以降で非推奨化・7.0で廃止予定だが、`vite-tsconfig-paths`のpeerDependenciesが`typescript: "^5.8.2"`(5.x系)のみをサポート対象としているため、今回は5.x系内での更新に留めた
- 6.x/7.xへの移行(tsconfig.jsonの`moduleResolution: "bundler"`化含む)は別タスクとする

## テスト計画

- [x] `npm run build`が成功することを確認
- [x] `npm run ci`(biome)が成功することを確認
- [x] `npm run test`が全て成功することを確認(541テスト)